### PR TITLE
chore: upgrade starting point to .NET 8

### DIFF
--- a/Odyssey.Liftoff.csproj
+++ b/Odyssey.Liftoff.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>


### PR DESCRIPTION
Upgrade to .NET 8. 

Needs course content updates in tandem. Push up new version of `final` branch after.